### PR TITLE
lib/shellAliases: add maisem alias

### DIFF
--- a/lib/shellAliases.nix
+++ b/lib/shellAliases.nix
@@ -20,6 +20,7 @@
   gs = "git status";
   gst = "git stash";
   gt = "git tag";
+  maisem = "cowsay -f moomoo 'maisem'
 
   godlv = "dlv exec --api-version 2 --listen=127.0.0.1:2345 --headless";
 }


### PR DESCRIPTION
Add silly cow-based maisem alias to generate an ASCII art cow saying 'maisem' for fun and giggles among coworkers.