### PR TITLE
lib/shellAliases: add grh alias for git reset --hard

### DIFF
--- a/lib/shellAliases.nix
+++ b/lib/shellAliases.nix
@@ -20,6 +20,7 @@
   gs = "git status";
   gst = "git stash";
   gt = "git tag";
+  grh = "git reset --hard";
 
   godlv = "dlv exec --api-version 2 --listen=127.0.0.1:2345 --headless";
 }


### PR DESCRIPTION
Add a shell alias for git reset --hard to make it easier to forcefully discard changes in working directory and align with other git shortcuts.